### PR TITLE
Fix make clean and phony targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,15 @@
-.PHONY: watch watch-browse clean all
-
 sources := browse.js editor.js
 
+.PHONY: all all-min
 all: $(sources:%.js=public/%-compiled.js)
 all-min: $(sources:%.js=public/%-compiled-min.js)
 
+.PHONY: clean
 clean:
-	rm public/*compiled*
+	rm -f public/*compiled*
 
 public/%-compiled.js: browser/%.js lib/*.js
 	browserify -i chalk -p yo-yoify $< -o $@
 
 public/%-compiled-min.js: browser/%.js lib/*.js
 	browserify -i chalk -p yo-yoify $< | buble | uglifyjs -cm > $@
-


### PR DESCRIPTION
• Allow clean to succeed when project is already clean (or never built)

• Update phony targets and reposition them next to their recipes so
  they're more contextual and less likely to become outdated